### PR TITLE
Fix for .tor paths having more than one period.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ forum_post.txt
 log.log
 log_parser.py
 .OPfallbacks
+
+#personal workspaces
+*.code-workspace

--- a/otls/gaea_tor_processor.hda/labs_8_8Sop_1gaea__tor__processor/PythonModule
+++ b/otls/gaea_tor_processor.hda/labs_8_8Sop_1gaea__tor__processor/PythonModule
@@ -134,10 +134,10 @@ def LoadXML(a_node):
     # Extract XML parm File
     RunGaea(a_node, cmd, gaea_dir)
 
-    if not os.path.isfile(os.path.abspath("".join(automation_file.split(".")[:-1])+".xml")):
+    if not os.path.isfile(os.path.abspath(".".join(automation_file.split(".")[:-1])+".xml")):
         return
 
-    XMLTree = ET.parse(os.path.abspath("".join(automation_file.split(".")[:-1])+".xml"))
+    XMLTree = ET.parse(os.path.abspath(".".join(automation_file.split(".")[:-1])+".xml"))
     XMLRoot = XMLTree.getroot()
     ParmGroup = a_node.parmTemplateGroup()
     FolderGroup = a_node.parm("generated_gaeaparms")

--- a/otls/gaea_tor_processor.hda/labs_8_8Sop_1gaea__tor__processor_8_82.0/PythonModule
+++ b/otls/gaea_tor_processor.hda/labs_8_8Sop_1gaea__tor__processor_8_82.0/PythonModule
@@ -161,10 +161,10 @@ def LoadXML(a_node):
     # Extract XML parm File
     RunGaea(a_node, cmd, gaea_dir)
 
-    if not os.path.isfile(os.path.abspath("".join(automation_file.split(".")[:-1])+".xml")):
+    if not os.path.isfile(os.path.abspath(".".join(automation_file.split(".")[:-1])+".xml")):
         return
 
-    XMLTree = ET.parse(os.path.abspath("".join(automation_file.split(".")[:-1])+".xml"))
+    XMLTree = ET.parse(os.path.abspath(".".join(automation_file.split(".")[:-1])+".xml"))
     XMLRoot = XMLTree.getroot()
     ParmGroup = a_node.parmTemplateGroup()
     FolderGroup = a_node.parm("generated_gaeaparms")


### PR DESCRIPTION
The xml files weren't loading because my paths contained another "." file as in /houdini18.0/
causing the join to remove those periods and fail to find the xml.