### PR TITLE
Small fix for High Quality Lighting

### DIFF
--- a/otls/matcap_shader.hda/labs_8_8Vop_1matcap__shader/Glsl150Fragment
+++ b/otls/matcap_shader.hda/labs_8_8Vop_1matcap__shader/Glsl150Fragment
@@ -163,7 +163,7 @@ void main()
  
     vec4 wire = HOUwireColor(fsIn.edgedist,fsIn.edgeflags,fsIn.selected);
     
-    HOUassignOutputs(vec3(0),
+    HOUassignOutputs(vec3(1),
                      tex.rgb, 
                      vec3(0), 
                      vec3(0),  
@@ -178,7 +178,7 @@ void main()
                      0.0,
                      0.0,  
                      wire, 
-                     vec3(0),  
+                     nN,  
                      0,   
                      fsIn.selected,
                      specular_model, coat_spec_model);


### PR DESCRIPTION
I did a small fix for High Quality Lighting. Now it will be possible to use Viewport's Ambient Occlusion with Matcaps.
Here is my previous report:
https://github.com/sideeffects/GameDevelopmentToolset/issues/162?fbclid=IwAR3PGC71yUiHeZnl7T1La3FCllQenojgq9SL4p33H_cBUnqsZIsIF_ArqoE