### PR TITLE
Niagara ROP: fixed issues when using python 3

### DIFF
--- a/otls/niagara_rop.hda/labs_8_8Driver_1niagara__rop/PythonModule
+++ b/otls/niagara_rop.hda/labs_8_8Driver_1niagara__rop/PythonModule
@@ -14,6 +14,19 @@ g_supported_attribute_data_types = (
     hou.attribData.Int,
 )
 
+
+class JSONBytesEncoder(json.JSONEncoder):
+    """ Encoder that encodes bytes to unicode. Intended for use in Python 3. """
+    def __init__(self, *args, **kwargs):
+        self._default_bytes_encoding = kwargs.pop('default_bytes_encoding', 'utf-8')
+        super(JSONBytesEncoder, self).__init__(*args, **kwargs)
+
+    def default(self, o):
+        if isinstance(o, bytes):
+            return o.decode(self._default_bytes_encoding)
+        return super(JSONBytesEncoder, self).default(o)
+
+
 def report_and_raise_error(message, exception_class):
     """ Convenience function for reporting (print or UI popup)
     an error and raising an exception.
@@ -393,7 +406,7 @@ def _export_json_frame_internal(node, frame, render_node, is_binary, file_handle
         
         point_data = []          
         attrib_component_index = 0
-        for attrib_name, point_attr in point_attribs.iteritems():
+        for attrib_name, point_attr in point_attribs.items():
             attrib_value = point.attribValue(point_attr)
             # expand attributes with more than one component
             # directly into the point_data array
@@ -454,9 +467,9 @@ def export_json_footer(node, render_node=None, niagara_data=None):
             file_handle.seek(0)
             niagara_data.dump_begin(file_handle)
     else:
-        with open(json_path, 'w') as file_handle:
+        with open(json_path, 'wt') as file_handle:
             # Dump the entire cache to text json
-            json.dump(niagara_data.to_dict(), file_handle)
+            json.dump(niagara_data.to_dict(), file_handle, cls=JSONBytesEncoder)
             
     if hasattr(hou.session, 'niagara_rop_instance_data'):
         # Clear the instance data for this ROP

--- a/otls/niagara_rop.hda/labs_8_8Sop_1niagara_8_82.0/DialogScript
+++ b/otls/niagara_rop.hda/labs_8_8Sop_1niagara_8_82.0/DialogScript
@@ -148,7 +148,7 @@
                     type    string
                     default { "" }
                     menureplace {
-                        [ "opmenu -l ropnet1/niagara_rop1 attr_to_cast1" ]
+                        [ "opmenu -l ropnet1/niagara_rop2 attr_to_cast1" ]
                     }
                     parmtag { "script_callback_language" "python" }
                 }
@@ -158,7 +158,7 @@
                     type    string
                     default { "" }
                     menu {
-                        [ "opmenu -l ropnet1/niagara_rop1 attr_type1" ]
+                        [ "opmenu -l ropnet1/niagara_rop2 attr_type1" ]
                     }
                     parmtag { "script_callback_language" "python" }
                 }


### PR DESCRIPTION
Fixed various bytes vs str issues when using Python 3 with the
Niagara ROP. The hbjson and Niagara ROP python modules now work
in Python 2.7 and Python 3.

Updated the menu script reference for the attr_type# multiparm in
the Niagara ROP SOP.