### PR TITLE
Fix extra data being written at the end of FGB file.

### DIFF
--- a/otls/vector_field.hda/labs_8_8Sop_1vector__field/PythonModule
+++ b/otls/vector_field.hda/labs_8_8Sop_1vector__field/PythonModule
@@ -108,7 +108,7 @@ def renderFGB(node):
                                 operation.updateProgress(percent)
 
                 if total_in_buffer > 0:
-                    chunk = buffer[0:((total_in_buffer+1)* dataformat.size)]
+                    chunk = buffer[0:(total_in_buffer * dataformat.size)]
                     out_stream.write(chunk)
             except hou.OperationInterrupted:
                 print ("User cancelled vector file save")


### PR DESCRIPTION
The +1 in the list slice is incorrect (as total_in_buffer is a count not an index), it causes 3 extra floats to be written out at the end of the file.