### PR TITLE
uniform word spacing, group icon with label

### DIFF
--- a/help/images/superformula_shapes_array.svg
+++ b/help/images/superformula_shapes_array.svg
@@ -1,1 +1,377 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1962 1005.1"><defs><style>.cls-1{fill:#fff;}.cls-2{fill:#565b68;}.cls-10,.cls-11,.cls-13,.cls-3,.cls-4,.cls-5,.cls-7,.cls-8,.cls-9{isolation:isolate;}.cls-10,.cls-11,.cls-13,.cls-4,.cls-5,.cls-7,.cls-8,.cls-9{font-size:30px;font-family:SourceSansPro-Regular, Source Sans Pro;}.cls-5{letter-spacing:0em;}.cls-6{letter-spacing:0em;}.cls-15,.cls-7{letter-spacing:-0.02em;}.cls-12,.cls-8{letter-spacing:-0.01em;}.cls-9{letter-spacing:-0.07em;}.cls-10{letter-spacing:-0.05em;}.cls-11{letter-spacing:-0.02em;}.cls-13{letter-spacing:-0.02em;}.cls-14{letter-spacing:-0.04em;}.cls-16{letter-spacing:-0.03em;}</style></defs><g id="Live_Type" data-name="Live Type"><rect class="cls-1" width="1962" height="1005.1"/><path class="cls-2" d="M704.76,732c3.36,33.69,7.22,35.21,39.46,29.29-16.13,27.88-14.69,33.41,15.13,46.23-28,13.4-32.55,17.61-15.4,45.72-.64,1.27-1.38,1-2.1.81-29.66-7.47-34.76-.45-37,28.66-13.2-11.23-22.51-28.15-39.41-9.7-3.36,2.42-6,8.3-9.8,9.26-4.6-32.3-7-34.68-39.73-27.86,14.14-24.89,16.94-33.55-12.43-45.21-.86-.4-1.81-.64-2.1-2,29.65-12.47,30.73-18.88,14.42-46.06,28.3,5.11,36.86,6.58,39.14-25.74.11-.92,0-1.93,1.31-2.58C677.25,757.05,684.13,755.72,704.76,732Z" transform="translate(3.01)"/><path class="cls-2" d="M1065.88,807.43c-48.77,53.49-110.91,53.24-160.15.51C954.5,754.2,1016.25,755.21,1065.88,807.43Z" transform="translate(3.01)"/><path class="cls-2" d="M1291,733.63c5.31,35.85,25.9,65.53,33.35,100.48,9.61,36.43-27.07,74.74-57.91,42C1236.32,832.81,1288.17,780,1291,733.63Z" transform="translate(3.01)"/><g class="cls-3"><text class="cls-4" transform="translate(1691.69 623.22)">Fl</text><text class="cls-5" transform="translate(1714.19 623.22)">o<tspan class="cls-6" x="16.14" y="0">w</tspan></text><text class="cls-4" transform="translate(1751.75 623.22)">er</text></g><g class="cls-3"><text class="cls-4" transform="translate(626.32 936.9)">Sunbu</text><text class="cls-4" transform="translate(708.01 936.9)">r</text><text class="cls-7" transform="translate(718.33 936.9)">s</text><text class="cls-4" transform="translate(730.3 936.9)">t</text></g><g class="cls-3"><text class="cls-8" transform="translate(966.66 936.9)">E</text><text class="cls-4" transform="translate(982.17 936.9)">y</text><text class="cls-4" transform="translate(996.09 936.9)">e</text></g><g class="cls-3"><text class="cls-9" transform="translate(1233.7 936.9)">T</text><text class="cls-8" transform="translate(1247.8 936.9)">e</text><text class="cls-4" transform="translate(1262.26 936.9)">ar D</text><text class="cls-8" transform="translate(1312.3 936.9)">r</text><text class="cls-4" transform="translate(1322.44 936.9)">op</text></g><path class="cls-2" d="M745.11,494.72c1.24-17.31-.83-35.73,4.59-52.62,12.68-39.76,77.86-25,110.58-26.72,37.27.95,46.94,26,46.24,59.27-.37,22.07,1.61,44.43-2.12,66.29-8.45,48-69.25,31.9-104.26,34.63C742.71,575.86,746.05,539.92,745.11,494.72Z" transform="translate(3.01)"/><path class="cls-2" d="M1136.42,571c-22.44-1.63-85.86,2.66-85.33-23.19,7.28-39.23,31-74.17,53.69-106.38,8.27-9.71,19.57-27.85,34.3-19.7,32.5,27.57,51.66,68.41,68.52,106.91,8.91,20.65,5.32,34.63-18.82,37.72C1173.71,569.14,1149.21,570.76,1136.42,571Z" transform="translate(3.01)"/><path class="cls-2" d="M295.05,495.23c-26,27.2-53.23,53.26-79.54,80C188,549.88,161.42,522.15,135,495.34c2.94-3.81,75.69-76.58,80-80C242.1,441.47,268.72,468.29,295.05,495.23Z" transform="translate(3.01)"/><path class="cls-2" d="M1447.05,485.16c17.87-5.85,34.15-16.24,53.54-16.2,21.1-1.57,17.49,26.6,15.73,40.57-5,28-52.93.46-68.43-3.82-1.48,2.39,1.72,5.35,2.35,7.8,5.6,13.59,24.67,52.82,4.32,60.07-12.23,2.67-42.07,6.72-43.57-11-1.12-18.56,7.32-35.78,14.58-52.35,4.39-8-3.71-3.25-7.29-1.6-14.61,6.64-30.17,12.91-46.44,13-19.9-.59-15.27-28-13.76-41.34,5.89-26.71,53.24-.13,68.74,5-3.6-13.55-11.84-25.81-14.25-40-5.23-21.18-.71-30.93,22.38-30.53,10.23.11,27.61-.62,28.31,13.17C1464.66,448.51,1454.05,466.52,1447.05,485.16Z" transform="translate(3.01)"/><path class="cls-2" d="M520.1,420.4c7.87,18.56,11.92,38,18.81,56.78,19.56,2,39.73-.61,59.53,0,.39,1.88-1,2.22-1.79,2.81-15.16,10.78-30.52,21.5-45.64,32.31,3.45,19.57,14.08,38,17.54,57.65-16.78-11.36-31.5-23.56-48.1-35-16.34,11.16-31.71,23.72-47.88,35.1-1.21-.62-.75-1.33-.53-2,6-18.25,12.41-36.4,18.24-54.72-15.41-12.66-32.58-22.74-48.19-35.18,19.28-2.52,39.84.56,59.65-.4C508.46,458.2,513.5,440.18,520.1,420.4Z" transform="translate(3.01)"/><text class="cls-4" transform="translate(160.45 623.25)">Diamond</text><g class="cls-3"><text class="cls-7" transform="translate(498.11 623.25)">S</text><text class="cls-7" transform="translate(513.41 623.25)">t</text><text class="cls-4" transform="translate(522.95 623.25)">ar</text></g><g class="cls-3"><text class="cls-4" transform="translate(777.55 623.25)">Squi</text><text class="cls-8" transform="translate(833.95 623.25)">r</text><text class="cls-4" transform="translate(844.09 623.25)">cle</text></g><g class="cls-3"><text class="cls-8" transform="translate(1077.6 623.25)">R</text><text class="cls-4" transform="translate(1094.4 623.25)">ounded </text><text class="cls-7" transform="translate(1083.77 659.25)">P</text><text class="cls-4" transform="translate(1100.06 659.25)">oly</text><text class="cls-8" transform="translate(1138 659.25)">g</text><text class="cls-4" transform="translate(1152.73 659.25)">on</text></g><g class="cls-3"><text class="cls-4" transform="translate(1400.09 623.25)">Cl</text><text class="cls-5" transform="translate(1424.87 623.25)">o<tspan class="cls-6" x="16.14" y="0">v</tspan></text><text class="cls-4" transform="translate(1454.93 623.25)">er</text></g><path class="cls-2" d="M295.71,216.75c-53.78-.29-107,.55-160-.32-2.08-52.51-.48-106.63-.7-159.63,1.33-1.47,2.93-1.15,4.41-1.15h31.49c41.43.71,83.47-1.38,124.6.77C296.14,63.07,297,172,295.71,216.75Z" transform="translate(3.01)"/><path class="cls-2" d="M601.38,136.4c-1.13,105.63-160.44,104.9-160.89-.24C441.8,30.78,599.86,30.23,601.38,136.4Z" transform="translate(3.01)"/><path class="cls-2" d="M1663,118.47c3.88-3.6,76-56,80.59-58.48,26.52,19.08,53,38.71,79.7,57.74-9.18,31.64-19.81,63.62-30.74,94.6-4,.57-62.22,1.58-98.71.22C1691.72,208.22,1665.52,128.21,1663,118.47Z" transform="translate(3.01)"/><path class="cls-2" d="M905.76,205.11c-52.33,1.79-106.08.88-158.78.52,24.92-46.42,52.57-92.13,79.13-137.8C854,112,880.29,159.28,905.76,205.11Z" transform="translate(3.01)"/><path class="cls-2" d="M1516.65,205.92c-53.52-.58-106.65,1.1-159.09-.62-.19-6.12-2.15-118.12.08-137C1411,112.57,1465,159.32,1516.65,205.92Z" transform="translate(3.01)"/><path class="cls-2" d="M1211.22,171H1053.65c-.45-1.9.86-2.35,1.63-3q21.83-19,43.7-37.9c11.18-9.06,21.42-19.79,33.11-28C1136.72,106,1203.4,161.33,1211.22,171Z" transform="translate(3.01)"/><g class="cls-3"><text class="cls-4" transform="translate(173.77 263.87)">Squa</text><text class="cls-8" transform="translate(237.88 263.87)">r</text><text class="cls-4" transform="translate(248.02 263.87)">e</text></g><g class="cls-3"><text class="cls-4" transform="translate(488.89 263.87)">Ci</text><text class="cls-8" transform="translate(513.43 263.87)">r</text><text class="cls-4" transform="translate(523.57 263.87)">cle</text></g><g class="cls-3"><text class="cls-10" transform="translate(774.7 263.87)">T</text><text class="cls-4" transform="translate(789.4 263.87)">riangle,</text><text class="cls-8" transform="translate(761.65 299.87)">E</text><text class="cls-4" transform="translate(777.16 299.87)">quil</text><text class="cls-11" transform="translate(825.19 299.87)">a<tspan class="cls-12" x="14.43" y="0">t</tspan></text><text class="cls-4" transform="translate(849.64 299.87)">e</text><text class="cls-7" transform="translate(864.52 299.87)">r</text><text class="cls-4" transform="translate(874.24 299.87)">al</text></g><g class="cls-3"><text class="cls-10" transform="translate(1080.7 263.87)">T</text><text class="cls-4" transform="translate(1095.4 263.87)">riangle,</text><text class="cls-4" transform="translate(1079.17 299.87)">Isos</text><text class="cls-13" transform="translate(1128.46 299.87)">c</text><text class="cls-4" transform="translate(1141.51 299.87)">eles</text></g><g class="cls-3"><text class="cls-10" transform="translate(1384.7 263.87)">T</text><text class="cls-4" transform="translate(1399.4 263.87)">riangle,</text><text class="cls-4" transform="translate(1406.25 299.87)">Right</text></g><g class="cls-3"><text class="cls-13" transform="translate(1650.9 281.21)">N-sided <tspan class="cls-14" x="98.31" y="0">P</tspan><tspan class="cls-15" x="114" y="0">oly</tspan><tspan class="cls-16" x="150.21" y="0">g</tspan><tspan x="164.34" y="0">on</tspan></text><text class="cls-3" x="3.01"/><text class="cls-3" x="3.01"/><text class="cls-3" x="3.01"/><text class="cls-3" x="3.01"/><text class="cls-3" x="3.01"/></g><path class="cls-2" d="M1731.49,470c2-1.24,2.14-3.32,2.79-5,2.1-5.5,3.91-11.1,6.06-16.57a125.3,125.3,0,0,1,11.46-22.86,75,75,0,0,1,5.86-7.69,15.38,15.38,0,0,1,3.94-3.19c2.18-1.27,4.14-.4,4.94,1.94a17.83,17.83,0,0,1,.45,7.89,88.65,88.65,0,0,1-5.87,22.53c-3.1,7.74-6.61,15.32-10,23-.91,2.07-1.91,4.1-3.11,6.66,1.27.07,2.21.41,2.87.11,3.12-1.36,6.17-2.91,9.25-4.38,11.49-5.48,23.19-10.41,35.76-12.82a67.88,67.88,0,0,1,10.17-.88,9.51,9.51,0,0,1,3.81.87,2.63,2.63,0,0,1,1.57,3.37,2.68,2.68,0,0,1-.19.42,17.29,17.29,0,0,1-3.36,4.51,81.12,81.12,0,0,1-9.08,6.81c-9.19,5.8-19.16,10-29.33,13.69-3.56,1.3-7.17,2.45-10.73,3.75a19.23,19.23,0,0,0-2.71,1.49c.41,2,1.94,2.12,3.09,2.55,4.63,1.7,9.33,3.2,13.94,4.94a139.71,139.71,0,0,1,25.6,12.27,95.61,95.61,0,0,1,9.11,6.78,15.55,15.55,0,0,1,3.17,4c1.28,2.13.45,4.19-2,4.88a18.9,18.9,0,0,1-4.49.55c-4.4.14-8.66-.85-12.9-1.91a162.88,162.88,0,0,1-29.79-11.09c-3.26-1.53-6.47-3.19-9.74-4.68a17.42,17.42,0,0,0-3-.78c-.94,1.76.11,2.86.62,4,2.29,5,4.78,9.91,7,14.94a136,136,0,0,1,9,26.34,58.25,58.25,0,0,1,1.38,9,23.37,23.37,0,0,1-.8,6.71,2.75,2.75,0,0,1-4.13,1.67,17.27,17.27,0,0,1-4.86-3.84,107.85,107.85,0,0,1-7.83-11.15A132,132,0,0,1,1739,536.67c-1.67-4.44-3.16-9-4.77-13.41-.51-1.42-1.14-2.8-1.78-4.17-.14-.29-.57-.46-.87-.69-1.79.87-1.87,2.78-2.44,4.31-1.74,4.61-3.22,9.33-5,13.93a133.94,133.94,0,0,1-12.75,26,75.68,75.68,0,0,1-7.06,8.89c-1.49,1.66-3.43,3.4-5.94,2.22-2.19-1-2.4-3.48-2.29-5.47a73.64,73.64,0,0,1,1.43-11.83c2.73-12.7,7.89-24.53,13.51-36.17,1.31-2.72,2.57-5.46,4.09-8.71-1.32,0-2.26-.36-2.94-.07-3,1.28-5.83,2.75-8.74,4.14-10.45,5-21.11,9.46-32.4,12.22-4.61,1.13-9.26,2.14-14,1.7a11.72,11.72,0,0,1-4.25-1.33,2.15,2.15,0,0,1-1-2.85.31.31,0,0,1,0-.1,15.3,15.3,0,0,1,3.19-4.61,99,99,0,0,1,11-8.08,137.37,137.37,0,0,1,24.17-11.53c3.91-1.47,7.86-2.81,11.78-4.23,1.76-.64,3.5-1.34,5-1.92.48-1.67-.46-2.07-1.32-2.39l-8.57-3c-9.67-3.4-19.21-7.13-28.11-12.27a112.79,112.79,0,0,1-11.83-7.85,22.22,22.22,0,0,1-4.81-5.51c-1.36-2-.36-4.19,2.08-4.8a20.54,20.54,0,0,1,4.5-.48,47,47,0,0,1,12.91,1.87,165.85,165.85,0,0,1,29.79,11.14c3.25,1.53,6.46,3.17,9.74,4.67a23.73,23.73,0,0,0,3.81,1c-.76-2-1.18-3.41-1.77-4.7-3.05-6.74-6.34-13.38-9.18-20.21-3.71-9-6.7-18.15-7.87-27.85a16.87,16.87,0,0,1,.46-7.89c.82-2.34,2.78-3.23,4.94-1.92a16.16,16.16,0,0,1,4.33,3.61,95.5,95.5,0,0,1,7,9.7c6.24,10.26,10.63,21.38,14.57,32.69.81,2.33,1.56,4.68,2.45,7A13.83,13.83,0,0,0,1731.49,470Z" transform="translate(3.01)"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="Layer_1"
+   data-name="Layer 1"
+   viewBox="0 0 1800 975"
+   version="1.1"
+   sodipodi:docname="superformula_shapes_array.svg"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   width="1800"
+   height="975"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview200"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="0.7623668"
+     inkscape:cx="545.01324"
+     inkscape:cy="647.3262"
+     inkscape:window-width="2560"
+     inkscape:window-height="1339"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3">
+    <inkscape:grid
+       type="xygrid"
+       id="grid522"
+       originx="0"
+       originy="0"
+       spacingx="150"
+       spacingy="75" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:#fff;}.cls-2{fill:#565b68;}.cls-10,.cls-11,.cls-13,.cls-3,.cls-4,.cls-5,.cls-7,.cls-8,.cls-9{isolation:isolate;}.cls-10,.cls-11,.cls-13,.cls-4,.cls-5,.cls-7,.cls-8,.cls-9{font-size:30px;font-family:SourceSansPro-Regular, Source Sans Pro;}.cls-5{letter-spacing:0em;}.cls-6{letter-spacing:0em;}.cls-15,.cls-7{letter-spacing:-0.02em;}.cls-12,.cls-8{letter-spacing:-0.01em;}.cls-9{letter-spacing:-0.07em;}.cls-10{letter-spacing:-0.05em;}.cls-11{letter-spacing:-0.02em;}.cls-13{letter-spacing:-0.02em;}.cls-14{letter-spacing:-0.04em;}.cls-16{letter-spacing:-0.03em;}</style>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer16"
+     inkscape:label="bg">
+    <rect
+       style="fill:#ffffff;fill-opacity:1"
+       id="rect918"
+       width="1800"
+       height="975"
+       x="0"
+       y="0"
+       ry="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer15"
+     inkscape:label="Tear Drop">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="1200.9219"
+       y="908.33594"
+       id="text1218"><tspan
+         sodipodi:role="line"
+         id="tspan1216"
+         x="1200.9219"
+         y="908.33594">Tear Drop</tspan></text>
+    <path
+       class="cls-2"
+       d="m 1199.5119,672.55117 c 5.31,35.85 25.9,65.53 33.35,100.48 9.61,36.43 -27.07,74.74 -57.91,42 -30.12,-43.3 21.73,-96.11 24.56,-142.48 z"
+       id="path12"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer14"
+     inkscape:label="Eye">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="899.28125"
+       y="908.33594"
+       id="text1214"><tspan
+         sodipodi:role="line"
+         id="tspan1212"
+         x="899.28125"
+         y="908.33594">Eye</tspan></text>
+    <path
+       class="cls-2"
+       d="m 980.075,749.69633 c -48.77,53.49 -110.91,53.24 -160.15,0.51 48.77,-53.74 110.52,-52.73 160.15,-0.51 z"
+       id="path10"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer13"
+     inkscape:label="Sunburst">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="599.32812"
+       y="911.92969"
+       id="text1210"><tspan
+         sodipodi:role="line"
+         id="tspan1208"
+         x="599.32812"
+         y="911.92969">Sunburst</tspan></text>
+    <path
+       class="cls-2"
+       d="m 624.395,674.645 c 3.36,33.69 7.22,35.21 39.46,29.29 -16.13,27.88 -14.69,33.41 15.13,46.23 -28,13.4 -32.55,17.61 -15.4,45.72 -0.64,1.27 -1.38,1 -2.1,0.81 -29.66,-7.47 -34.76,-0.45 -37,28.66 -13.2,-11.23 -22.51,-28.15 -39.41,-9.7 -3.36,2.42 -6,8.3 -9.8,9.26 -4.6,-32.3 -7,-34.68 -39.73,-27.86 14.14,-24.89 16.94,-33.55 -12.43,-45.21 -0.86,-0.4 -1.81,-0.64 -2.1,-2 29.65,-12.47 30.73,-18.88 14.42,-46.06 28.3,5.11 36.86,6.58 39.14,-25.74 0.11,-0.92 0,-1.93 1.31,-2.58 21,24.23 27.88,22.9 48.51,-0.82 z"
+       id="path8"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer12"
+     inkscape:label="Flower">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="1648.4297"
+       y="611.92969"
+       id="text1206"><tspan
+         sodipodi:role="line"
+         id="tspan1204"
+         x="1648.4297"
+         y="611.92969">Flower</tspan></text>
+    <path
+       class="cls-2"
+       d="m 1649.8937,425.82714 c 2,-1.24 2.14,-3.32 2.79,-5 2.1,-5.5 3.91,-11.1 6.06,-16.57 a 125.3,125.3 0 0 1 11.46,-22.86 75,75 0 0 1 5.86,-7.69 15.38,15.38 0 0 1 3.94,-3.19 c 2.18,-1.27 4.14,-0.4 4.94,1.94 a 17.83,17.83 0 0 1 0.45,7.89 88.65,88.65 0 0 1 -5.87,22.53 c -3.1,7.74 -6.61,15.32 -10,23 -0.91,2.07 -1.91,4.1 -3.11,6.66 1.27,0.07 2.21,0.41 2.87,0.11 3.12,-1.36 6.17,-2.91 9.25,-4.38 11.49,-5.48 23.19,-10.41 35.76,-12.82 a 67.88,67.88 0 0 1 10.17,-0.88 9.51,9.51 0 0 1 3.81,0.87 2.63,2.63 0 0 1 1.57,3.37 2.68,2.68 0 0 1 -0.19,0.42 17.29,17.29 0 0 1 -3.36,4.51 81.12,81.12 0 0 1 -9.08,6.81 c -9.19,5.8 -19.16,10 -29.33,13.69 -3.56,1.3 -7.17,2.45 -10.73,3.75 a 19.23,19.23 0 0 0 -2.71,1.49 c 0.41,2 1.94,2.12 3.09,2.55 4.63,1.7 9.33,3.2 13.94,4.94 a 139.71,139.71 0 0 1 25.6,12.27 95.61,95.61 0 0 1 9.11,6.78 15.55,15.55 0 0 1 3.17,4 c 1.28,2.13 0.45,4.19 -2,4.88 a 18.9,18.9 0 0 1 -4.49,0.55 c -4.4,0.14 -8.66,-0.85 -12.9,-1.91 a 162.88,162.88 0 0 1 -29.79,-11.09 c -3.26,-1.53 -6.47,-3.19 -9.74,-4.68 a 17.42,17.42 0 0 0 -3,-0.78 c -0.94,1.76 0.11,2.86 0.62,4 2.29,5 4.78,9.91 7,14.94 a 136,136 0 0 1 9,26.34 58.25,58.25 0 0 1 1.38,9 23.37,23.37 0 0 1 -0.8,6.71 2.75,2.75 0 0 1 -4.13,1.67 17.27,17.27 0 0 1 -4.86,-3.84 107.85,107.85 0 0 1 -7.83,-11.15 132,132 0 0 1 -10.41,-22.16 c -1.67,-4.44 -3.16,-9 -4.77,-13.41 -0.51,-1.42 -1.14,-2.8 -1.78,-4.17 -0.14,-0.29 -0.57,-0.46 -0.87,-0.69 -1.79,0.87 -1.87,2.78 -2.44,4.31 -1.74,4.61 -3.22,9.33 -5,13.93 a 133.94,133.94 0 0 1 -12.75,26 75.68,75.68 0 0 1 -7.06,8.89 c -1.49,1.66 -3.43,3.4 -5.94,2.22 -2.19,-1 -2.4,-3.48 -2.29,-5.47 a 73.64,73.64 0 0 1 1.43,-11.83 c 2.73,-12.7 7.89,-24.53 13.51,-36.17 1.31,-2.72 2.57,-5.46 4.09,-8.71 -1.32,0 -2.26,-0.36 -2.94,-0.07 -3,1.28 -5.83,2.75 -8.74,4.14 -10.45,5 -21.11,9.46 -32.4,12.22 -4.61,1.13 -9.26,2.14 -14,1.7 a 11.72,11.72 0 0 1 -4.25,-1.33 2.15,2.15 0 0 1 -1,-2.85 0.31,0.31 0 0 1 0,-0.1 15.3,15.3 0 0 1 3.19,-4.61 99,99 0 0 1 11,-8.08 137.37,137.37 0 0 1 24.17,-11.53 c 3.91,-1.47 7.86,-2.81 11.78,-4.23 1.76,-0.64 3.5,-1.34 5,-1.92 0.48,-1.67 -0.46,-2.07 -1.32,-2.39 l -8.57,-3 c -9.67,-3.4 -19.21,-7.13 -28.11,-12.27 a 112.79,112.79 0 0 1 -11.83,-7.85 22.22,22.22 0 0 1 -4.81,-5.51 c -1.36,-2 -0.36,-4.19 2.08,-4.8 a 20.54,20.54 0 0 1 4.5,-0.48 47,47 0 0 1 12.91,1.87 165.85,165.85 0 0 1 29.79,11.14 c 3.25,1.53 6.46,3.17 9.74,4.67 a 23.73,23.73 0 0 0 3.81,1 c -0.76,-2 -1.18,-3.41 -1.77,-4.7 -3.05,-6.74 -6.34,-13.38 -9.18,-20.21 -3.71,-9 -6.7,-18.15 -7.87,-27.85 a 16.87,16.87 0 0 1 0.46,-7.89 c 0.82,-2.34 2.78,-3.23 4.94,-1.92 a 16.16,16.16 0 0 1 4.33,3.61 95.5,95.5 0 0 1 7,9.7 c 6.24,10.26 10.63,21.38 14.57,32.69 0.81,2.33 1.56,4.68 2.45,7 a 13.83,13.83 0 0 0 1.43,2.28 z"
+       id="path196"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer11"
+     inkscape:label="Clover">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="1349.1016"
+       y="611.92969"
+       id="text1202"><tspan
+         sodipodi:role="line"
+         id="tspan1200"
+         x="1349.1016"
+         y="611.92969">Clover</tspan></text>
+    <path
+       class="cls-2"
+       d="m 1359.9319,439.80327 c 17.87,-5.85 34.15,-16.24 53.54,-16.2 21.1,-1.57 17.49,26.6 15.73,40.57 -5,28 -52.93,0.46 -68.43,-3.82 -1.48,2.39 1.72,5.35 2.35,7.8 5.6,13.59 24.67,52.82 4.32,60.07 -12.23,2.67 -42.07,6.72 -43.57,-11 -1.12,-18.56 7.32,-35.78 14.58,-52.35 4.39,-8 -3.71,-3.25 -7.29,-1.6 -14.61,6.64 -30.17,12.91 -46.44,13 -19.9,-0.59 -15.27,-28 -13.76,-41.34 5.89,-26.71 53.24,-0.13 68.74,5 -3.6,-13.55 -11.84,-25.81 -14.25,-40 -5.23,-21.18 -0.71,-30.93 22.38,-30.53 10.23,0.11 27.61,-0.62 28.31,13.17 1.4,20.58 -9.21,38.59 -16.21,57.23 z"
+       id="path60"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer10"
+     inkscape:label="Rounded Polygon">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="1049.8828"
+       y="588.60675"
+       id="text1196"><tspan
+         sodipodi:role="line"
+         id="tspan1194"
+         x="1049.8828"
+         y="588.60675">Rounded</tspan><tspan
+         sodipodi:role="line"
+         x="1049.8828"
+         y="629.04944"
+         id="tspan1198">Polygon</tspan></text>
+    <path
+       class="cls-2"
+       d="m 1054.8516,525.65972 c -22.44,-1.63 -85.86004,2.66 -85.33004,-23.19 7.28,-39.23 31.00004,-74.17 53.69004,-106.38 8.27,-9.71 19.57,-27.85 34.3,-19.7 32.5,27.57 51.66,68.41 68.52,106.91 8.91,20.65 5.32,34.63 -18.82,37.72 -15.07,2.78 -39.57,4.4 -52.36,4.64 z"
+       id="path56"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="Squircle">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="749.79688"
+       y="608.82812"
+       id="text1192"><tspan
+         sodipodi:role="line"
+         id="tspan1190"
+         x="749.79688"
+         y="608.82812">Squircle</tspan></text>
+    <path
+       class="cls-2"
+       d="m 669.19472,449.64456 c 1.24,-17.31 -0.83,-35.73 4.59,-52.62 12.68,-39.76 77.86,-25 110.58,-26.72 37.27,0.95 46.94,26 46.24,59.27 -0.37,22.07 1.61,44.43 -2.12,66.29 -8.45,48 -69.25,31.9 -104.26,34.63 -57.43,0.29 -54.09,-35.65 -55.03,-80.85 z"
+       id="path54"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer8"
+     inkscape:label="Star">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="448.94531"
+       y="611.64844"
+       id="text1188"><tspan
+         sodipodi:role="line"
+         id="tspan1186"
+         x="448.94531"
+         y="611.64844">Star</tspan></text>
+    <path
+       class="cls-2"
+       d="m 449.80119,375.175 c 7.87,18.56 11.92,38 18.81,56.78 19.56,2 39.73,-0.61 59.53,0 0.39,1.88 -1,2.22 -1.79,2.81 -15.16,10.78 -30.52,21.5 -45.64,32.31 3.45,19.57 14.08,38 17.54,57.65 -16.78,-11.36 -31.5,-23.56 -48.1,-35 -16.34,11.16 -31.71,23.72 -47.88,35.1 -1.21,-0.62 -0.75,-1.33 -0.53,-2 6,-18.25 12.41,-36.4 18.24,-54.72 -15.41,-12.66 -32.58,-22.74 -48.19,-35.18 19.28,-2.52 39.84,0.56 59.65,-0.4 6.72,-19.55 11.76,-37.57 18.36,-57.35 z"
+       id="path62"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer7"
+     inkscape:label="Diamond">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="149.88281"
+       y="611.92969"
+       id="text1184"><tspan
+         sodipodi:role="line"
+         id="tspan1182"
+         x="149.88281"
+         y="611.92969">Diamond</tspan></text>
+    <path
+       class="cls-2"
+       d="m 230.025,449.945 c -26,27.2 -53.23,53.26 -79.54,80 -27.51,-25.35 -54.09,-53.08 -80.51,-79.89 2.94,-3.81 75.69,-76.58 80,-80 27.1,26.13 53.72,52.95 80.05,79.89 z"
+       id="path58"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="N-sided Polygon">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="1649.7891"
+       y="308.82812"
+       id="text1180"><tspan
+         sodipodi:role="line"
+         id="tspan1178"
+         x="1649.7891"
+         y="308.82812">N-sided Polygon</tspan></text>
+    <path
+       class="cls-2"
+       d="m 1569.855,131.86069 c 3.88,-3.6 76,-56.000001 80.59,-58.480001 26.52,19.08 53,38.710001 79.7,57.740001 -9.18,31.64 -19.81,63.62 -30.74,94.6 -4,0.57 -62.22,1.58 -98.71,0.22 -2.12,-4.33 -28.32,-84.34 -30.84,-94.08 z"
+       id="path110"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="Triangle, Right">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="1351.6094"
+       y="288.60678"
+       id="text1170"><tspan
+         sodipodi:role="line"
+         x="1351.6094"
+         y="288.60678"
+         id="tspan1172">Triangle,</tspan><tspan
+         sodipodi:role="line"
+         x="1351.6094"
+         y="329.04947"
+         id="tspan1176">Right</tspan></text>
+    <path
+       class="cls-2"
+       d="m 1430.0337,218.72012 c -53.52,-0.58 -106.65,1.1 -159.09,-0.62 -0.19,-6.12 -2.15,-118.120005 0.08,-137.000005 53.36,44.270005 107.36,91.020005 159.01,137.620005 z"
+       id="path114"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Triangle, Isosceles">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="1049.2109"
+       y="291.70834"
+       id="text1164"><tspan
+         sodipodi:role="line"
+         id="tspan1162"
+         x="1049.2109"
+         y="291.70834">Triangle,</tspan><tspan
+         sodipodi:role="line"
+         x="1049.2109"
+         y="332.15103"
+         id="tspan1166">Isosceles</tspan></text>
+    <path
+       class="cls-2"
+       d="M 1128.8309,184.45 H 971.26091 c -0.45,-1.9 0.86,-2.35 1.63,-3 q 21.83,-19 43.69999,-37.9 c 11.18,-9.06 21.42,-19.79 33.11,-28 4.63,3.9 71.31,59.23 79.13,68.9 z"
+       id="path116"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Triangle, Equilateral">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="749.92969"
+       y="288.60678"
+       id="text1109"><tspan
+         sodipodi:role="line"
+         id="tspan1107"
+         x="749.92969"
+         y="288.60678">Triangle,</tspan><tspan
+         sodipodi:role="line"
+         x="749.92969"
+         y="329.04947"
+         id="tspan1111">Equilateral</tspan></text>
+    <path
+       class="cls-2"
+       d="m 829.39,218.1037 c -52.33,1.79 -106.08,0.88 -158.78,0.52 24.92,-46.42 52.57,-92.13 79.13,-137.800003 27.89,44.170003 54.18,91.450003 79.65,137.280003 z"
+       id="path112"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Circle">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="449.95312"
+       y="311.92969"
+       id="text1105"><tspan
+         sodipodi:role="line"
+         id="tspan1103"
+         x="449.95312"
+         y="311.92969">Circle</tspan></text>
+    <path
+       class="cls-2"
+       d="m 530.445,150.26606 c -1.13,105.63 -160.44,104.9 -160.89,-0.24 1.31,-105.379998 159.37,-105.929998 160.89,0.24 z"
+       id="path108"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Square">
+    <text
+       xml:space="preserve"
+       style="font-size:32px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;display:inline;fill:#000000"
+       x="149.79688"
+       y="308.54688"
+       id="text1101"><tspan
+         sodipodi:role="line"
+         id="tspan1099"
+         x="149.79688"
+         y="308.54688"
+         style="font-size:32px">Square</tspan></text>
+    <path
+       class="cls-2"
+       d="m 230.20596,230.62234 c -53.78,-0.29 -107,0.55 -160.000002,-0.32 -2.08,-52.51 -0.48,-106.63 -0.7,-159.63 1.33,-1.47 2.93,-1.15 4.41,-1.15 h 31.490002 c 41.43,0.71 83.47,-1.38 124.6,0.77 0.63,6.65 1.49,115.58 0.2,160.33 z"
+       id="path106"
+       style="display:inline;fill:#565b68;fill-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
The labels in file has non-uniform word spacing(and some charaters have overlapped with each other), and has been split into fragments that are hard to edit. I recreate the label for a uniform word spacing, then group icons with its own label for better organized. 
![superformula_shapes_array_old](https://user-images.githubusercontent.com/10928361/171988076-4299fc8e-3e69-4efd-ba80-bb693d695316.png)

![superformula_shapes_array_new](https://user-images.githubusercontent.com/10928361/171988188-ec88373a-3852-48b5-a9fe-406f13cbd5c9.png)
