### PR TITLE
[NEWTOOL] **Labs Object Merge Tools** Added new tools for efficient o…

### DIFF
--- a/NetworkViewMenu.xml
+++ b/NetworkViewMenu.xml
@@ -100,6 +100,29 @@ network_organize.node_to_network_origin()
                     ]]>
                 </scriptCode>
             </scriptItem>
+            <separatorItem id="labs_network_view_menu_sep3"/>
+            <titleItem id="node_object_merge_title">
+                <label>Object Merge Tools</label>
+            </titleItem>
+            <scriptItem id="labs_copy_nodes_for_object_merge">
+                <label>Copy Selected Nodes</label>
+                <scriptCode>
+                    <![CDATA[
+from labsopui import node_utils
+node_utils.copy_nodes_for_object_merge()
+                    ]]>
+                </scriptCode>
+            </scriptItem>
+            <scriptItem id="labs_paste_as_object_merge_nodes">
+                <label>Paste in Current Pane</label>
+                <scriptCode>
+                    <![CDATA[
+from labsopui import node_utils
+node_utils.paste_as_object_merge_nodes(kwargs['editor'])
+                    ]]>
+                </scriptCode>
+            </scriptItem>
+            <separatorItem id="labs_network_view_menu_sep4"/>
             <subMenu id="labs_network_view_menu_more">
                 <label>More</label>
                 <scriptItem id="labs_node_to_network_origin_with_images">

--- a/scripts/python/labsopui/node_utils.py
+++ b/scripts/python/labsopui/node_utils.py
@@ -1,0 +1,69 @@
+import os
+import tempfile
+import hou
+import importlib
+import sys
+
+def reload_module():
+    """Force reload the node_utils module to ensure latest changes are applied."""
+    if 'labsopui.node_utils' in sys.modules:
+        importlib.reload(sys.modules['labsopui.node_utils'])
+
+def copy_nodes_for_object_merge():
+    """Copy selected nodes for object merge."""
+    reload_module()  # Reload module to ensure latest changes
+    nodes = hou.selectedNodes()
+    if not nodes:
+        hou.ui.displayMessage("No nodes selected.", severity=hou.severityType.Warning)
+    else:
+        # Use a fixed temp file path for cross-platform compatibility
+        temp_file_path = os.path.join(tempfile.gettempdir(), "pyobjpath.txt")
+        with open(temp_file_path, 'w') as temp_file:
+            for n in nodes:
+                temp_file.write(n.path() + '\n')
+
+def paste_as_object_merge_nodes(editor):
+    """Paste as object merge nodes in the specified editor."""
+    reload_module()  # Reload module to ensure latest changes
+    if not editor:
+        hou.ui.displayMessage("No active Network Editor pane found.", severity=hou.severityType.Warning)
+    else:
+        # Get the current network context from the editor
+        current_network = editor.pwd()
+        # Use selectPosition for interactive placement
+        pos = editor.selectPosition()
+        
+        # Use the same temp file path as the copy command
+        temp_file_path = os.path.join(tempfile.gettempdir(), "pyobjpath.txt")
+        # Debug information
+        # print("Temporary file path: " + temp_file_path)
+        if not os.path.exists(temp_file_path):
+            hou.ui.displayMessage("No saved node paths found.", severity=hou.severityType.Warning)
+        else:
+            with open(temp_file_path, 'r') as fl:
+                paths = fl.readlines()
+            if not paths:
+                hou.ui.displayMessage("No node paths found in file.", severity=hou.severityType.Warning)
+            else:
+                names = [path.strip().split('/')[-1] for path in paths]
+                objmNodes = []
+                for i, path in enumerate(paths):
+                    # Create node in the current network context
+                    objmerge = current_network.createNode('object_merge')
+                    objmerge.setPosition(hou.Vector2(pos[0] + i, pos[1] - i * 0.5))
+                    abspath = path.strip()
+                    relpath = objmerge.relativePathTo(hou.node(abspath))
+                    objmerge.parm('objpath1').set(relpath)
+                    objmerge.parm('xformtype').set('local')
+                    objmerge.setSelected(1)
+                    objmerge.setName('MERGE_' + names[i] + '_1', unique_name=True)
+                    # Copy the color of the original node
+                    original_node = hou.node(abspath)
+                    if original_node:
+                        objmerge.setColor(original_node.color())
+                    objmNodes.append(objmerge)
+                
+                # Focus the network view on the newly created nodes
+                if objmNodes:
+                    editor.setCurrentNode(objmNodes[-1])
+                    editor.homeToSelection() 


### PR DESCRIPTION
Object merge node creation, integrated from Wei Hu's HUTools, which was developed over 9 years. Features include interactive node placement, color preservation, and automatic network view focusing.
This link shows how it works in the Labs context. 
https://www.notion.so/Object-Merge-Tools-20c450e1986e808ebcd1f09f7570e7bd?source=copy_link


## Overview
The Object Merge Tools provide a powerful way to create object merge nodes that reference selected nodes across different network contexts in Houdini. These tools are particularly useful for creating references to nodes in subnets, parent networks, or any other network context.

## Features

### Copy Selected Nodes
- Select multiple nodes in any network context
- Stores the paths of selected nodes for later use
- Supports batch selection of multiple nodes
- Works across different network contexts (subnets, parent networks, etc.)

### Paste in Current Pane
- Creates object merge nodes in the current network context
- Automatically positions nodes in a staggered layout
- Preserves the original node's color
- Sets up proper relative paths for object merging
- Focuses the network view on newly created nodes
- Supports interactive placement using the cursor position
- Works in any network context (subnets, parent networks, etc.)

## Key Benefits
1. **Cross-Context References**: Create references to nodes in any network context
2. **Batch Processing**: Handle multiple nodes simultaneously
3. **Visual Consistency**: Maintains original node colors for better visual organization
4. **Smart Placement**: Automatically arranges nodes in a readable layout
5. **Interactive Placement**: Place nodes at cursor position for precise control
6. **Network Context Awareness**: Works seamlessly across different network contexts

## Usage
1. Select the nodes you want to reference
2. Use "Copy Selected Nodes" to store their paths
3. Navigate to the target network context (subnet, parent network, etc.)
4. Use "Paste in Current Pane" to create object merge nodes
5. The new nodes will be created at the cursor position with proper relative paths

This toolset is particularly useful when working with complex node networks, subnets, or when you need to create references to nodes in different network contexts while maintaining proper relative paths and visual organization.
