### PR TITLE
[Gaea] Fix decoding error for Gaea Terrain Processor

### DIFF
--- a/scripts/python/gaea/processing_utils.py
+++ b/scripts/python/gaea/processing_utils.py
@@ -876,7 +876,7 @@ def ensure_gaea_service(gaea_executable: str) -> None:
     if platform.system() == "Windows":
         try:
             process = subprocess.run(
-                ["tasklist"],
+                ["tasklist", "/nh"],
                 stdout=subprocess.PIPE,
                 text=True,
                 startupinfo=get_startupinfo(),


### PR DESCRIPTION
This PR removes the column names in the tasklist command which gets run to find process ids. This would throw errors for users which use Japanese characters.