### PR TITLE
[Update] **Labs ZibraVDB Plugin 1.4** - Updated ZibraVDB tools to 1.4 for H21.

### DIFF
--- a/help/nodes/lop/labs--zibravdb_import-1.0.txt
+++ b/help/nodes/lop/labs--zibravdb_import-1.0.txt
@@ -9,12 +9,12 @@
 """References ZibraVDB data on disk into a volume prim containing field prims."""
 
 
-As a part of the [ZibraVDB for Houdini|https://www.zibra.ai] plugin, this node loads a single, highly compressed `.zibravdb` file from disk and creates volume and field primitives that point to the contained data. The file may contain either a single frame or a frame sequence of VDB geometry.
+As a part of the [ZibraVDB for Houdini|https://www.zibra.ai] plugin, this node loads a single, highly compressed `.cvdb` file from disk and creates volume and field primitives that point to the contained data. The file may contain either a single frame or a frame sequence of VDB geometry.
 
 The compression often achieves up to 97–99% reduction in VDB file size with minimal quality loss. The compression rate is adjustable for each VDB field, providing independent control over the quality and memory footprint of `density`, `temperature`, `flame`, and other standard or custom fields. Up to 8 float fields can be compressed simultaneously.
 
 NOTE:
-    ZibraVDB for Houdini ships with a custom USD Asset Resolver that decompresses `.zibravdb` files into OpenVDB. The decompressed OpenVDB file path is provided to USD as the resolved path.
+    ZibraVDB for Houdini ships with a custom USD Asset Resolver that decompresses `.cvdb` files into OpenVDB. The decompressed OpenVDB file path is provided to USD as the resolved path.
 
 TIP:
     If you want ZibraVDB files imported with this node to be linked in a USD file, add ZibraVDB Output Processor to the list of Output Processors on the USD ROP node.
@@ -41,7 +41,7 @@ TIP:
 
     ZibraVDB File:
         #id: file
-        The file path which the compressed VDB geometry will be loaded from. The file extension must be `.zibravdb`.
+        The file path which the compressed VDB geometry will be loaded from. The file extension must be `.cvdb`.
 
     Frame Index:
         #id: frame

--- a/help/nodes/out/labs--zibravdb_compress-1.0.txt
+++ b/help/nodes/out/labs--zibravdb_compress-1.0.txt
@@ -6,10 +6,10 @@
 
 = Labs ZibraVDB Compress =
 
-"""Compresses a VDB sequence and caches it to disk as a single  `.zibravdb` file."""
+"""Compresses a VDB sequence and caches it to disk as a single  `.cvdb` file."""
 
 
-As a part of the [ZibraVDB for Houdini |https://www.zibra.ai] plugin, this node caches a VDB sequence to disk as a single, highly compressed `.zibravdb` file. It can compress both animated VDB sequences and static VDB geometries.
+As a part of the [ZibraVDB for Houdini |https://www.zibra.ai] plugin, this node caches a VDB sequence to disk as a single, highly compressed `.cvdb` file. It can compress both animated VDB sequences and static VDB geometries.
 
 The compression often achieves up to 97–99% reduction in VDB file size with minimal quality loss. The compression rate is adjustable for each VDB field, providing independent control over the quality and memory footprint of `density`, `temperature`, `flame`, and other standard or custom fields. Up to 8 float fields can be compressed simultaneously.
 
@@ -59,10 +59,17 @@ You need to obtain a license key to start using the plugin.
 
         You may also use the [package mechanism|https://www.sidefx.com/docs/houdini/ref/plugins.html] to set environment variables.
 
+:disclosure:ZibraVDB file extensions and license types
+    Different ZibraVDB licenses produce files with different extensions:
+    
+    - __.cvdbe__ produced by the Education license. Can be opened only with the same license.
+    - __.cvdbf__ produced by the Free license. Can be opened with a Free or Education license.
+    - __.cvdb__ produced by the Studio license. Can be opened with any license.
+
 
 == About ZibraVDB == (aboutzibravdb)
 
-[ZibraVDB|https://effects.zibra.ai/zibravdb-virtual-production] is a cutting-edge [VDB compression and real-time rendering technology|https://youtu.be/c8FQ_jidNH0?si=jKj1Rxj30FXA0err] developed by [Zibra AI|https://effects.zibra.ai/]. The compression can currently achieve up to 97–99% reduction in VDB file size with minimal quality loss. The proprietary `.zibravdb` file format captures an entire VDB sequence in a single file, which can be loaded into applications such as Houdini or Unreal Engine, decompressed on the GPU in real time, and played back in the viewport at speeds significantly faster than native solutions.
+[ZibraVDB|https://effects.zibra.ai/zibravdb-virtual-production] is a cutting-edge [VDB compression and real-time rendering technology|https://youtu.be/c8FQ_jidNH0?si=jKj1Rxj30FXA0err] developed by [Zibra AI|https://effects.zibra.ai/]. The compression can currently achieve up to 97–99% reduction in VDB file size with minimal quality loss. The proprietary `.cvdb` file format captures an entire VDB sequence in a single file, which can be loaded into applications such as Houdini or Unreal Engine, decompressed on the GPU in real time, and played back in the viewport at speeds significantly faster than native solutions.
 
 For artists, this provides a memory-efficient, high-performance volumetric data pipeline that seamlessly integrates into existing workflows.
 
@@ -70,7 +77,7 @@ It significantly reduces storage costs, improves volumetric data I/O speeds, and
 
 [ZibraVDB for Houdini|https://github.com/ZibraAI/ZibraVDBForHoudini], contributed by Zibra AI, is a SideFX Labs plugin that brings ZibraVDB’s compression, decompression, and accelerated playback capabilities into Houdini’s ecosystem.
 
-Additionally, the compressed `.zibravdb` files can be used with [ZibraVDB for UE|https://www.fab.com/listings/23aef313-3c6a-40ea-810d-35de2ea5bca2]. This empowers artists to bring stunning volumetric effects created in Houdini to Unreal Engine and render them efficiently as full 3D ray-marched volumes in real time.
+Additionally, the compressed `.cvdb` files can be used with [ZibraVDB for UE|https://www.fab.com/listings/23aef313-3c6a-40ea-810d-35de2ea5bca2]. This empowers artists to bring stunning volumetric effects created in Houdini to Unreal Engine and render them efficiently as full 3D ray-marched volumes in real time.
 
 
 == Feedback and Support == (feedback)
@@ -112,7 +119,7 @@ You can also contact [SideFX Support|https://www.sidefx.com/support-programs/] a
     
     Out File:
         #id: filename
-        The file path where the compressed VDB geometry will be saved. The file extension must be `.zibravdb`. Any missing directories in the path will be automatically created.
+        The file path where the compressed VDB geometry will be saved. The file extension must be `.cvdb`. Any missing directories in the path will be automatically created.
 
     Quality:
         #id: quality

--- a/help/nodes/sop/labs--rop_zibravdb_compress-1.0.txt
+++ b/help/nodes/sop/labs--rop_zibravdb_compress-1.0.txt
@@ -6,10 +6,10 @@
 
 = Labs ZibraVDB Compress =
 
-"""Compresses a VDB sequence and caches it to disk as a single  `.zibravdb` file."""
+"""Compresses a VDB sequence and caches it to disk as a single  `.cvdb` file."""
 
 
-As a part of the [ZibraVDB for Houdini |https://www.zibra.ai] plugin, this node caches a VDB sequence to disk as a single, highly compressed `.zibravdb` file. It can compress both animated VDB sequences and static VDB geometries.
+As a part of the [ZibraVDB for Houdini |https://www.zibra.ai] plugin, this node caches a VDB sequence to disk as a single, highly compressed `.cvdb` file. It can compress both animated VDB sequences and static VDB geometries.
 
 The compression often achieves up to 97–99% reduction in VDB file size with minimal quality loss. The compression rate is adjustable for each VDB field, providing independent control over the quality and memory footprint of `density`, `temperature`, `flame`, and other standard or custom fields. Up to 8 float fields can be compressed simultaneously.
 

--- a/help/nodes/sop/labs--zibravdb_decompress-1.0.txt
+++ b/help/nodes/sop/labs--zibravdb_decompress-1.0.txt
@@ -6,10 +6,10 @@
 
 = Labs ZibraVDB Decompress =
 
-"""Loads a single `.zibravdb` file from disk and decompresses it as a VDB sequence."""
+"""Loads a single `.cvdb` file from disk and decompresses it as a VDB sequence."""
 
 
-As a part of the [ZibraVDB for Houdini |https://www.zibra.ai] plugin, this node loads a single, highly compressed `.zibravdb` file from disk. The file may contain either a single frame or a frame sequence of VDB geometry. In both cases, the entire sequence is loaded at once, with frames decompressed on demand using a frame index parameter.
+As a part of the [ZibraVDB for Houdini |https://www.zibra.ai] plugin, this node loads a single, highly compressed `.cvdb` file from disk. The file may contain either a single frame or a frame sequence of VDB geometry. In both cases, the entire sequence is loaded at once, with frames decompressed on demand using a frame index parameter.
 
 This significantly speeds up playback for high-resolution VDBs by eliminating the need to load one frame from disk at a time. Additionally, the total size of the data to be loaded is much smaller. The decompression occurs on the GPU and is extremely fast.
 
@@ -35,7 +35,7 @@ TIP:
 
     Input File:
         #id: filename
-        The file path from which to load the compressed VDB geometry. The file extension must be `.zibravdb`.
+        The file path from which to load the compressed VDB geometry. The file extension must be `.cvdb`.
 
     Sequence Frame:
         #id: frame
@@ -43,7 +43,7 @@ TIP:
 
     Reload Cache:
         #id: refresh
-        Forces a reload of the `.zibravdb` file from disk and refreshes the decompressed frame.
+        Forces a reload of the `.cvdb` file from disk and refreshes the decompressed frame.
 
     :include /nodes/out/labs--zibravdb_compress-1.0#openmanagement:
 

--- a/help/nodes/sop/labs--zibravdb_filecache-1.0.txt
+++ b/help/nodes/sop/labs--zibravdb_filecache-1.0.txt
@@ -6,14 +6,14 @@
 
 = Labs ZibraVDB File Cache =
 
-"""Performs compression and caching, or loading and decompression, of a VDB sequence to or from a single `.zibravdb` file."""
+"""Performs compression and caching, or loading and decompression, of a VDB sequence to or from a single `.cvdb` file."""
 
 
 As a part of the [ZibraVDB for Houdini |https://www.zibra.ai] plugin, this node combines the functionalities of the [Labs ZibraVDB Compress SOP|Node:sop/labs--rop_zibravdb_compress-1.0] and the [Labs ZibraVDB Decompress SOP|Node:sop/labs--zibravdb_decompress-1.0]. It can compress/decompress both animated VDB sequences and static VDB geometries.
 
 Similar to the [File Cache SOP|Node:sop/filecache], this node operates in two modes: 
-* Caching mode: Compresses a VDB sequence and caches it to disk as a single  `.zibravdb` file.
-* Loading mode: Loads a single `.zibravdb` file from disk and decompresses it as a VDB sequence.
+* Caching mode: Compresses a VDB sequence and caches it to disk as a single  `.cvdb` file.
+* Loading mode: Loads a single `.cvdb` file from disk and decompresses it as a VDB sequence.
 
 The compression often achieves up to 97–99% reduction in VDB file size with minimal quality loss. The compression rate is adjustable for each VDB field, providing independent control over the quality and memory footprint of `density`, `temperature`, `flame`, and other standard or custom fields. Up to 8 float fields can be compressed simultaneously.
 
@@ -44,13 +44,13 @@ TIP:
 
     Load from Disk:
         #id: loadfromdisk
-        If on, loads and decompresses the `.zibravdb` file specified in __File__ instead of cooking the input geometry.
+        If on, loads and decompresses the `.cvdb` file specified in __File__ instead of cooking the input geometry.
 
     :include /nodes/sop/labs--zibravdb_decompress-1.0#refresh:
     
     File:
         #id: file
-        The file path which the compressed VDB geometry will be saved to or loaded from. The file extension must be `.zibravdb`. During caching, any missing directories in the path will be automatically created.
+        The file path which the compressed VDB geometry will be saved to or loaded from. The file extension must be `.cvdb`. During caching, any missing directories in the path will be automatically created.
 
     == Caching == (caching)
 

--- a/otls/zibravdb_filecache.1.0.hda/INDEX__SECTION
+++ b/otls/zibravdb_filecache.1.0.hda/INDEX__SECTION
@@ -10,5 +10,5 @@ Inputs:       0 to 1
 Subnet:       true
 Python:       false
 Empty:        false
-Modified:     Wed Nov 19 06:27:16 2025
+Modified:     Wed May 20 16:46:57 2026
 

--- a/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/Contents.dir/Contents.createtimes
+++ b/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/Contents.dir/Contents.createtimes
@@ -11,7 +11,7 @@
 	"hdaroot/IN.def":1726217455,
 	"hdaroot/output0.def":1726217245,
 	"hdaroot/python1.def":1763543858,
-	"hdaroot.def":1763543751,
+	"hdaroot.def":1779288363,
 	"hdaroot/groupdelete1.def":1726217517,
 	"hdaroot/rop_zibravdb_compress.def":1743415544,
 	"hdaroot/convertvdb1.def":1726688029

--- a/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/Contents.dir/Contents.houdini_versions
+++ b/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/Contents.dir/Contents.houdini_versions
@@ -1,5 +1,5 @@
 {
-	"values":["20.5.550","___EXTERNAL___"
+	"values":["21.0.631"
 	],
 	"indexes":{
 		"hdaroot/rop_zibravdb_compress.userdata":0,
@@ -11,7 +11,7 @@
 		"hdaroot/output0.userdata":0,
 		"hdaroot/groupdelete1.userdata":0,
 		"hdaroot/OUT_CACHE.userdata":0,
-		"hdaroot/python1.userdata":1,
+		"hdaroot/python1.userdata":0,
 		"hdaroot/input_error.userdata":0,
 		"hdaroot/IN.userdata":0
 	}

--- a/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/Contents.dir/Contents.mime
+++ b/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/Contents.dir/Contents.mime
@@ -32,7 +32,7 @@ Content-Type: text/plain
 
 sopflags sopflags = 
 comment ""
-position -0.592937 0.100929
+position -3.58203 -0.15
 connectornextid 0
 flags =  lock off model off template off footprint off xray off bypass off display on render on highlight off unload off savedata off compress on colordefault off exposed on
 outputsNamed3
@@ -48,7 +48,7 @@ stat
 {
   create -1
   modify -1
-  author dmytrobulatov1@dmytros-macbook-pro.local
+  author dmytr@BOOLKA_PC_JAPAN
   access 0777
 }
 color UT_Color RGB 0.9 0.8 0.55 
@@ -721,6 +721,7 @@ snippet	[ 0	locks=0 ]	(	"if (primintrinsic(0, \"typename\", @primnum) == \"VDB\"
 }"	)
 exportlist	[ 0	locks=0 ]	(	*	)
 vex_strict	[ 0	locks=0 ]	(	"off"	)
+vex_strictvariables	[ 0	locks=0 ]	(	"on"	)
 autobind	[ 0	locks=0 ]	(	"on"	)
 bindings	[ 0	locks=0 ]	(	0	)
 groupautobind	[ 0	locks=0 ]	(	"on"	)
@@ -800,6 +801,7 @@ vex_threadjobsize	[ 0	locks=0 ]	(	1024	)
 snippet	[ 0	locks=0 ]	(	"s@_zfc_unsupported = s@_zfc_unsupported[:-2];"	)
 exportlist	[ 0	locks=0 ]	(	*	)
 vex_strict	[ 0	locks=0 ]	(	"off"	)
+vex_strictvariables	[ 0	locks=0 ]	(	"on"	)
 autobind	[ 0	locks=0 ]	(	"on"	)
 bindings	[ 0	locks=0 ]	(	0	)
 groupautobind	[ 0	locks=0 ]	(	"on"	)

--- a/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/Contents.dir/Contents.modtimes
+++ b/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/Contents.dir/Contents.modtimes
@@ -11,7 +11,7 @@
 	"hdaroot/IN.def":1763543849,
 	"hdaroot/output0.def":1737117047,
 	"hdaroot/python1.def":1763543956,
-	"hdaroot.def":1763544439,
+	"hdaroot.def":1779288448,
 	"hdaroot/groupdelete1.def":1737116691,
 	"hdaroot/rop_zibravdb_compress.def":1743424189,
 	"hdaroot/convertvdb1.def":1737116691

--- a/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/DialogScript
+++ b/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/DialogScript
@@ -50,7 +50,7 @@
         name    "file"
         label   "File"
         type    file
-        default { "$HIP/vol/$HIPNAME.$OS.zibravdb" }
+        default { "$HIP/vol/$HIPNAME.$OS.cvdb" }
         menureplace {
             [ "opmenu -l -a rop_zibravdb_compress filename" ]
         }

--- a/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/ExtraFileOptions
+++ b/otls/zibravdb_filecache.1.0.hda/labs_8_8Sop_1zibravdb__filecache_8_81.0/ExtraFileOptions
@@ -1,7 +1,7 @@
 {
 	"OnCreated/Cursor":{
 		"type":"intarray",
-		"value":[3,51]
+		"value":[3,1]
 	},
 	"OnCreated/IsExpr":{
 		"type":"bool",


### PR DESCRIPTION
- Implemented updated licensing. Changed default file extension from ".zibravdb" to ".cvdb"/".cvdbe" /".cvdbf", depending on the user's license. Old .zibravdb files can still be opened normally.
- Added support for reading new ".cvdb"/".cvdbe"/".cvdbf" files.
- Updated minimum supported library version to 0.10.0.0 (Users will need to re-download the library).